### PR TITLE
feat: adjust and respect the template_path setting in config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "semi": true
   },
   "devDependencies": {
+    "@types/ini": "^1.3.31",
     "@types/node": "^16.11.41",
     "@types/rimraf": "^3.0.2",
     "@types/tmp": "^0.2.3",
@@ -139,6 +140,7 @@
     ]
   },
   "dependencies": {
+    "ini": "^4.1.1",
     "toml": "^3.0.0"
   }
 }

--- a/src/doqEngine.ts
+++ b/src/doqEngine.ts
@@ -3,9 +3,27 @@ import { ExtensionContext, OutputChannel, Range, TextDocument, Uri, window, work
 import cp from 'child_process';
 import fs from 'fs';
 import path from 'path';
+
+import ini from 'ini';
 import tmp from 'tmp';
+import toml from 'toml';
 
 import { getDoqPath } from './common';
+
+type DoqTemplatePath = {
+  doq?: {
+    template_path?: string;
+  };
+};
+
+type SetupCfgForDoqTemplatePath = DoqTemplatePath;
+
+type PyprojectTomlForDoqTemplatePath = {
+  tool?: DoqTemplatePath;
+};
+
+const WORKSPACE_PYPROJECT_TOML_PATH = path.join(workspace.root, 'pyproject.toml');
+const WORKSPACE_SETUP_CFG_PATH = path.join(workspace.root, 'setup.cfg');
 
 export async function doFormat(
   context: ExtensionContext,
@@ -55,6 +73,11 @@ export async function doFormat(
       // relative path
       args.push('--template_path', path.join(workspace.root, templatePath));
     }
+  }
+
+  const templatePathFromConfigFile = getDoqTemplatePathFromConfigFile();
+  if (!templatePath && templatePathFromConfigFile) {
+    args.push('--template_path', templatePathFromConfigFile);
   }
 
   if (isIgnoreException) {
@@ -112,4 +135,46 @@ export async function doFormat(
       resolve(text);
     });
   });
+}
+
+function getDoqTemplatePathFromConfigFile(): string | undefined {
+  let templatePath: string | undefined;
+
+  if (fs.existsSync(WORKSPACE_PYPROJECT_TOML_PATH)) {
+    // pyproject.toml
+    try {
+      const fileStr = fs.readFileSync(WORKSPACE_PYPROJECT_TOML_PATH, { encoding: 'utf-8' });
+      const data: PyprojectTomlForDoqTemplatePath = toml.parse(fileStr);
+      if (data.tool?.doq?.template_path) {
+        templatePath = data.tool.doq.template_path;
+      }
+    } catch (e) {
+      window.showErrorMessage('Failed to load TOML file. There may be a syntax error.');
+      throw e;
+    }
+  } else if (fs.existsSync(WORKSPACE_SETUP_CFG_PATH)) {
+    // setup.cfg
+    try {
+      const fileStr = fs.readFileSync(WORKSPACE_SETUP_CFG_PATH, { encoding: 'utf-8' });
+      const data: SetupCfgForDoqTemplatePath = ini.parse(fileStr);
+      if (data.doq?.template_path) {
+        templatePath = data.doq.template_path;
+      }
+    } catch (e) {
+      window.showErrorMessage('Failed to load INI file. There may be a syntax error.');
+      throw e;
+    }
+  }
+
+  if (templatePath) {
+    if (templatePath.startsWith('/')) {
+      // absolute path
+      return templatePath;
+    } else {
+      // relative path
+      return path.join(workspace.root, templatePath);
+    }
+  }
+
+  return templatePath;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/ini@^1.3.31":
+  version "1.3.31"
+  resolved "https://registry.yarnpkg.com/@types/ini/-/ini-1.3.31.tgz#c78541a187bd88d5c73e990711c9d85214800d1b"
+  integrity sha512-8ecxxaG4AlVEM1k9+BsziMw8UsX0qy3jYI1ad/71RrDZ+rdL6aZB0wLfAuflQiDhkD5o4yJ0uPK3OSUic3fG0w==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -727,6 +732,11 @@ inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-4.1.1.tgz#d95b3d843b1e906e56d6747d5447904ff50ce7a1"
+  integrity sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==
 
 is-extglob@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
In `coc-pydocstring`, for safety reasons, the file being executed is copied to a temporary directory outside of the project. Then, the doq command is executed. Only if the `doq` command completes successfully, the current buffer is overwritten.

I'm not sure if this is related to the mechanism, but when using a relative path in the `template_path` setting of the project's `pyproject.toml` or `setup.cfg`, the configuration may not be respected correctly. This can result in either the configuration not being applied correctly or errors occurring during execution.

Therefore, in the `coc-pydocstring`, we have implemented the following functionality to operate as follows.

1. Detects the project's pyproject.toml or setup.cfg file.
   - As an additional note, in coc-pydocstring, if the pyproject.toml or setup.cfg file exists, it will become the root of the workspace, depending on the settings in `contributes.rootPatterns`.
2. If there is a configuration value for `template_path` for "doq", it is retrieved.
3. If the `template_path` configuration is a relative path, it is converted to an absolute path.
4. Add the --template_path option when executing the doq command.

---

Close https://github.com/yaegassy/coc-pydocstring/issues/16